### PR TITLE
An attempt to improve perf as much as I can

### DIFF
--- a/src/utils/ascii.js
+++ b/src/utils/ascii.js
@@ -2,20 +2,43 @@
 
 import { fromLength, toLength } from './length.js';
 
-const { fromCharCode } = String;
-export { fromCharCode };
-
 /**
- * @param {Uint8Array} ui8
+ * Convert numbers and dates into strings.
+ * @param {Uint8Array} ui8a
  * @param {import("../decode.js").Position} at
  * @returns
  */
-export const fromASCII = (ui8, at) => {
-  const length = fromLength(ui8, at);
-  return fromCharCode(...ui8.slice(at.i, (at.i += length)));
+export const fromASCII = (ui8a, at) => {
+  const length = fromLength(ui8a, at);
+  const value = ui8a.subarray(at.i, (at.i += length));
+  let s = '';
+  for (let i = 0; i < length; i++) {
+    switch (value[i]) {
+      case 48: s += '0'; break;
+      case 49: s += '1'; break;
+      case 50: s += '2'; break;
+      case 51: s += '3'; break;
+      case 52: s += '4'; break;
+      case 53: s += '5'; break;
+      case 54: s += '6'; break;
+      case 55: s += '7'; break;
+      case 56: s += '8'; break;
+      case 57: s += '9'; break;
+      case 45: s += '-'; break;
+      case 46: s += '.'; break;
+      case 58: s += ':'; break;
+      case 84: s += 'T'; break;
+      case 90: s += 'Z'; break;
+      case 101: s += 'e'; break;
+      case 69: s += 'E'; break;
+      default: s += '+'; break;
+    }
+  }
+  return s;
 };
 
 /**
+ * Convert numbers and dates into numbers.
  * @param {number[]} ui8
  * @param {number} type
  * @param {string} value
@@ -23,6 +46,28 @@ export const fromASCII = (ui8, at) => {
 export const toASCII = (ui8, type, value) => {
   const { length } = value;
   toLength(ui8, type, length);
-  for (let i = 0; i < length; i++)
-    ui8.push(value.charCodeAt(i));
+  for (let i = 0; i < length; i++) {
+    switch (value[i]) {
+      case '0': ui8.push(48); break;
+      case '1': ui8.push(49); break;
+      case '2': ui8.push(50); break;
+      case '3': ui8.push(51); break;
+      case '4': ui8.push(52); break;
+      case '5': ui8.push(53); break;
+      case '6': ui8.push(54); break;
+      case '7': ui8.push(55); break;
+      case '8': ui8.push(56); break;
+      case '9': ui8.push(57); break;
+      case '-': ui8.push(45); break;
+      case '.': ui8.push(46); break;
+      case ':': ui8.push(58); break;
+      case 'T': ui8.push(84); break;
+      default: ui8.push(90); break;
+      // ⚠️ this is never the case in JS encoding
+      // case 'Z': ui8.push(90); break;
+      // case 'e': ui8.push(101); break;
+      // case 'E': ui8.push(69); break;
+      // default: ui8.push(43); break;
+    }
+  }
 };

--- a/test/cover.js
+++ b/test/cover.js
@@ -85,3 +85,13 @@ catch ({ message }) {
 }
 
 assert(decode(some, { recursion: 'some' }).join(','), [[],'a', 'a'].join(','));
+
+encode(new Uint8Array(1 << 0).buffer);
+encode(new Uint8Array(1 << 8).buffer);
+encode(new Uint8Array(1 << 16).buffer);
+encode(new Uint8Array(1 << 24).buffer);
+
+assert(decode(new Uint8Array([110, 1, 4, 43, 49, 101, 50])), 1e2);
+assert(decode(new Uint8Array([110, 1, 4, 43, 49, 69, 50])), 1E2);
+
+encode(() => {});


### PR DESCRIPTION
This MR is trying to use everything it could to boost performance *at least* for most common cases:

  * avoid creation of new ArrayBuffer whenever it's possible
  * decouple buffers from strings
  * use a fixed amount of memory to help encoding (slightly faster on *NodeJS* side, I couldn't see much of an improvement on the Web)
  * use `subarray` instead of `slice` anyway, as that's the way to do it