### PR TITLE
Fix #6 - BOOLEANs now take 1 byte

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Both *JSON* and *StructuredClone* are supported, where former types could potent
 | name      | value | char  |
 |:--------- | :---- | :---- |
 | ARRAY     | `65`  | A     |
-| BOOLEAN   | `98`  | b     |
+| FALSE     | `98`  | b     |
+| TRUE      | `99`  | c     |
 | NULL      | `0`   |       |
 | NUMBER    | `110` | n     |
 | OBJECT    | `79`  | O     |
@@ -194,7 +195,7 @@ In *JS* case, that is `new TextEncoder().encode(string)` which produces already 
 ### JSON types to Binary Conversion
 
   * **ARRAY** has its `type`, `length` and *values* as such: `[65, ...Length(array), ...encodedValues]`. All values encoded must be a known *type* and, whenever that's not the case, a `NULL` type is stored instead, like it is for `JSON.stringify([1, Incompatible(), 2])` which results into `[1, null, 2]`
-  * **BOOLEAN** has its `type` and either `1` or `0` as value: `[98, 1]` for *true* and `[98, 0]` for *false
+  * **BOOLEAN** is either `[98]` (char for `b`) for `false` and `[99]` for `true` (which is *false* + `1`)
   * **NULL** has only its `type`: `[0]`
   * **NUMBER** has its `type` and its stringified content as value: `[110, ...Length(ASCIIString(value)), ...ASCIIString(value)]`, preserving potentially huge numbers integrity
   * **OBJECT** has its `type`, *key* / *value* pairs length, and each *key* / *value* encoded after: `[79, ...Length(kvParis), ...kvParis]`

--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -80,7 +80,8 @@ When a serializable value is *encoded* it means that it returned an array of *ui
 Each serializable value in this space has its own array representation as standalone, working, buffered view of its value.
 
 ```js
-encode(true)        // [98, 1]
+encode(false)       // [98]
+encode(true)        // [99]
 encode(null)        // [0]
 encode(1)           // [110, 1, 1, 49]
 encode('a')         // [115, 1, 1, 97]
@@ -297,14 +298,14 @@ Where `110` is the ASCII code associated to the char `n`.
 Booleans are represented as such:
 
 ```js
-// True
-[98, 1]
-
 // False
-[98, 0]
+[98]
+
+// True
+[99]
 ```
 
-Where `98` is the ASCII code associated to the char `b`.
+Where `98` is the ASCII code associated to the char `b` and `99` is just `98 + 1` for *true*.
 
   </div>
 </details>
@@ -734,7 +735,8 @@ When a serialized value is *decoded* it means that it returned any compatible va
 By contract, *decode* needs to handle any `[type, ...codes]` possible combination, where each combination will be described in the next paragraphs, but here there's a *gist*:
 
 ```js
-decode([98, 1])                       // true
+decode([98])                          // false
+decode([99])                          // true
 decode([0])                           // null
 decode([110, 1, 1, 49])               // 1
 decode([115, 1, 1, 97])               // 'a'
@@ -760,7 +762,7 @@ const encoded =  [
   79,             // type
   1,  2,          // length of key/value pairs
   115, 1, 1, 98,  // first key (string)
-  98,   1         // first value (boolean)
+  99              // first value (boolean)
 ];
 
 decode(encoded)
@@ -797,9 +799,9 @@ Accordingly with its *encoding*, an *array* (*list* or *tuple* in *Python*) has 
 const encoded =  [
   65,             // type
   1,  2,          // length of values
-  98,   1,        // first value (boolean)
-  98,   0         // second value (boolean)
-];
+  99,             // first value (boolean)
+  98,             // second value (boolean)
+]
 
 decode(encoded)
 // [true, false]
@@ -889,24 +891,20 @@ In current *JS* implementation, the latest is done via `parseFloat` which can ha
 Accordingly with its *encoding*, a *boolean* is a `2` *codes* *array* with both *type*, which is `98`, and the *true* or *false* value as second entry:
 
 ```js
-decode([98, 1])
+decode([99])
 // true
 
-decode([98, 0])
+decode([98])
 // false
 ```
 
 A *meta* implementation of this algorithm can be described as such:
 
 ```js
-// current decoding position
-let index = 0;
-
-type(encoded)  // 98 => string
-
-let boolean = encoded[index++];
-// true or false
+type(encoded) // 98 => `false` or 99 => `true`
 ```
+
+Any `boolean` value does not need extra work: if the *type* is either `98` or `99` nothing else needs to be done.
 
   </div>
 </details>

--- a/src/constants.js
+++ b/src/constants.js
@@ -25,5 +25,6 @@ export const ERROR     = /** @type {101} */(  $('e')  );
 export const REGEXP     = /** @type {82} */(  $('R')  );
 export const STRING    = /** @type {115} */(  $('s')  );
 
-export const BOOLEAN    = /** @type {98} */(  $('b')  );
+export const FALSE      = /** @type {98} */(  $('b')  );
+export const TRUE       = /** @type {99} */(  $('c')  );
 export const FUNCTION  = /** @type {102} */(  $('f')  );

--- a/src/decode.js
+++ b/src/decode.js
@@ -2,7 +2,8 @@
 
 import {
   NULL,
-  BOOLEAN,
+  TRUE,
+  FALSE,
   NUMBER,
   STRING,
   ARRAY,
@@ -98,7 +99,8 @@ class Decoder {
       case ARRAY:     return this.array(track(this.m, as, []));
       case STRING:    return this.string(as);
       case NUMBER:    return this.number(as, parseFloat);
-      case BOOLEAN:   return this.a[this.i++] === 1;
+      case TRUE:      return true;
+      case FALSE:     return false;
       case NULL:      return null;
       case DATE:      return track(this.m, as, new Date(this.ascii()));
       case MAP:       return this.map(track(this.m, as, new Map));

--- a/src/encode.js
+++ b/src/encode.js
@@ -2,7 +2,8 @@
 
 import {
   NULL,
-  BOOLEAN,
+  TRUE,
+  FALSE,
   NUMBER,
   STRING,
   ARRAY,
@@ -167,7 +168,7 @@ class Encoder {
       }
       case 'string': this.string(value); break;
       case 'number': this.number(value); break;
-      case 'boolean': pushValues(this, [BOOLEAN, value ? 1 : 0]); break;
+      case 'boolean': pushValue(this, value ? TRUE : FALSE); break;
       case 'bigint': this.bigint(value); break;
       default: if (asNull) pushValue(this, NULL); break;
     }

--- a/types/constants.d.ts
+++ b/types/constants.d.ts
@@ -14,5 +14,6 @@ export const TYPED: 84;
 export const ERROR: 101;
 export const REGEXP: 82;
 export const STRING: 115;
-export const BOOLEAN: 98;
+export const FALSE: 98;
+export const TRUE: 99;
 export const FUNCTION: 102;


### PR DESCRIPTION
As simple as that, `98`, the char `b`, is reserved for *boolean* `false` value, while "*false + 1*", which is `99`, means `true`.