### PR TITLE
Fix #12 - Better ImageData & generic constructors

### DIFF
--- a/src/decode.js
+++ b/src/decode.js
@@ -45,6 +45,12 @@ const { fromCharCode } = String;
 const decoder = new TextDecoder;
 
 /**
+ * @param {number} length
+ * @returns
+ */
+const alloc = length => new Array(length);
+
+/**
  * @param {number} at
  */
 const throwOnRecursion = at => {
@@ -112,7 +118,7 @@ class Decoder {
       case RECURSIVE: return this.m.get(this.length()) ?? throwOnRecursion(as);
       // JSON arrays / objects
       case OBJECT:    return this.object(track(this.m, as, {}));
-      case ARRAY:     return this.array(track(this.m, as, new Array(this.length())));
+      case ARRAY:     return this.array(track(this.m, as, alloc(this.length())));
       // strings
       // case ASCII:     return this.string(as, true);
       case STRING:    return this.string(as);
@@ -176,14 +182,14 @@ class Decoder {
   }
 
   /* c8 ignore next 11 */
+  /**
+   * @param {number} as
+   * @returns {ImageData}
+   */
   imageData(as) {
-    const data = this.decode();
-    const width = this.decode();
-    const height = this.decode();
-    this.i++;
-    const colorSpace = /** @type {PredefinedColorSpace} */(this.ascii());
-    const ui8c = new Uint8ClampedArray(data.buffer);
-    const value = new ImageData(ui8c, width, height, { colorSpace });
+    const [{ buffer }, ...rest] = this.array(alloc(this.length()));
+    //@ts-ignore
+    const value = new ImageData(new Uint8ClampedArray(buffer), ...rest);
     this.m.set(as, value);
     return value;
   }

--- a/src/encode.js
+++ b/src/encode.js
@@ -209,11 +209,11 @@ class Encoder {
    */
   imageData(value) {
     this.track(0, value);
-    pushValue(this, IMAGEDATA);
+    pushLength(this, IMAGEDATA, 4);
     this.encode(value.data, false);
-    this.encode(value.width, false);
-    this.encode(value.height, false);
-    asASCII(this, STRING, value.colorSpace);
+    this.number(NUMBER, value.width);
+    this.number(NUMBER, value.height);
+    this.object(OBJECT, ['colorSpace', value.colorSpace]);
   }
 
   /**

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -10,7 +10,11 @@ context.fillRect(0, 0, canvas.width, canvas.height);
 
 const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
 
-const clone = decode(encode(imageData));
+const [a, clone, b, _, c] = decode(encode(['a', imageData, 'b', imageData, 'c']));
+console.assert(a === 'a');
+console.assert(b === 'b');
+console.assert(c === 'c');
+console.assert(clone === _);
 canvas = document.createElement('canvas');
 canvas.width = clone.width;
 canvas.height = clone.height;


### PR DESCRIPTION
This MR simplifies constructors with variable amount of arguments such as *ImageData* without blocking its future portability by simply storing the type as an array of arguments to be used to revive the instance.

It's still up to implementations' details to understand one or more arguments but this feels the right approach to take.